### PR TITLE
accept json body for search query

### DIFF
--- a/server/src/main/java/com/memegle/server/controller/PictureController.java
+++ b/server/src/main/java/com/memegle/server/controller/PictureController.java
@@ -90,7 +90,7 @@ public class PictureController {
 
         Pageable pageable = PageRequest.of(query.page, ELE_PER_PAGE);
 
-        LOGGER.info("Querying keyword=" + query.keyword + " page=" + query.page);
+        LOGGER.info("Querying:\n" + query);
 
         return searchRepo.searchName(query.keyword, pageable)
                 .stream()

--- a/server/src/main/java/com/memegle/server/dto/SearchQuery.java
+++ b/server/src/main/java/com/memegle/server/dto/SearchQuery.java
@@ -3,4 +3,12 @@ package com.memegle.server.dto;
 public class SearchQuery {
     public String keyword;
     public int page;
+
+    @Override
+    public String toString() {
+        return "{" + "\n" +
+                "keyword=" + keyword + "\n" +
+                "page=" + page + "\n" +
+                "}";
+    }
 }


### PR DESCRIPTION
后端/search现在可以接收来自get request中的json body了。
一个get query example：
curl -i \
-H "Accept: application/json" \
-H "Content-Type:application/json" \
-X GET --data '{"keyword": "哈哈哈", "page": 0}' "http://localhost:8080/search"