### PR TITLE
fix es port 9200 error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - cluster.name=docker-cluster
       - xpack.security.enabled=false
       - discovery.type=single-node
+      - network.host=0.0.0.0
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:


### PR DESCRIPTION
Fix Port:9200 error on MacOS build, for more info: https://stackoverflow.com/questions/31677563/elasticsearch-failed-to-connect-to-localhost-port-9200-connection-refused 
